### PR TITLE
index: Add old IE support

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,5 +7,8 @@
   "scripts": [
     "index.js"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "development": {
+    "component/assert": "*"
+  }
 }

--- a/index.js
+++ b/index.js
@@ -14,11 +14,11 @@ module.exports = function parallel(fns, context, callback) {
   var finished = false
   var results = new Array(pending)
 
-  fns.forEach(context ? function (fn, i) {
+
+  for (var i = 0, l = fns.length; i < l; i++) {
+    var fn = fns[i]
     fn.call(context, maybeDone(i))
-  } : function (fn, i) {
-    fn(maybeDone(i))
-  })
+  }
 
   function maybeDone(i) {
     return function (err, result) {

--- a/test.html
+++ b/test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='utf8'>
+    <title>array-parallel tests</title>
+  </head>
+  <body>
+    <script src='build/build.js'></script>
+    <script src='test.js'></script>
+  </body>
+</html>

--- a/test.js
+++ b/test.js
@@ -1,5 +1,9 @@
 var assert = require('assert')
-var parallel = require('./')
+try {
+  var parallel = require('array-parallel')
+} catch (e) {
+  var parallel = require('./')
+}
 
 var a, b, c
 parallel([
@@ -57,6 +61,6 @@ parallel([function (done) {
   done()
 }])
 
-process.nextTick(function () {
+setTimeout(function () {
   assert.equal(f, true)
 })


### PR DESCRIPTION
This patch replaces the usage of `Array#forEach` with a simple `for`
loop.  Browsers from the 1800s don't support much.

In addition, a `test.html` file and an `assert` dep have been added for
testing in the browser.